### PR TITLE
Bump couchbase to 429

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
 			],
 			"dependencies": {
 				"@parcel/watcher": "2.3.0",
-				"couchbase": "4.2.8",
+				"couchbase": "^4.2.9",
 				"desktop-trampoline": "https://github.com/desktop/desktop-trampoline/archive/refs/tags/v0.9.8.tar.gz",
 				"kerberos": "2.0.3",
 				"kerberos-plugins": "git+https://github.com/hackolade/kerberos.git",
@@ -49,9 +49,9 @@
 			}
 		},
 		"node_modules/@couchbase/couchbase-darwin-arm64-napi": {
-			"version": "4.2.8",
-			"resolved": "https://registry.npmjs.org/@couchbase/couchbase-darwin-arm64-napi/-/couchbase-darwin-arm64-napi-4.2.8.tgz",
-			"integrity": "sha512-39HdHfkNLehF5fKpniWkGbSUTVZnodyPJ9uO/eso3S3uE3Si4oXzaimObt9JLbnJGZdJ9Xh2hF4dExDmgWRzAQ==",
+			"version": "4.2.9",
+			"resolved": "https://registry.npmjs.org/@couchbase/couchbase-darwin-arm64-napi/-/couchbase-darwin-arm64-napi-4.2.9.tgz",
+			"integrity": "sha512-XDRWSFKXGk2wsQbva7Zc+Atu1Xdqnj1EA9Xble7TsSDdN/6l0RO2t5uvRQYhZ5BBq0h8SFOD27e5Df1gHNTCEg==",
 			"cpu": [
 				"arm64"
 			],
@@ -64,9 +64,9 @@
 			}
 		},
 		"node_modules/@couchbase/couchbase-darwin-x64-napi": {
-			"version": "4.2.8",
-			"resolved": "https://registry.npmjs.org/@couchbase/couchbase-darwin-x64-napi/-/couchbase-darwin-x64-napi-4.2.8.tgz",
-			"integrity": "sha512-hxf8mgi57u37tkJqX4sxkYLlcEje4IijFUBkes2YlhnlfcLvJY/bToj3/rbGlgq19NPqLm9j9JyLyVu8OdrGGw==",
+			"version": "4.2.9",
+			"resolved": "https://registry.npmjs.org/@couchbase/couchbase-darwin-x64-napi/-/couchbase-darwin-x64-napi-4.2.9.tgz",
+			"integrity": "sha512-URBW2V2XEDXXEC/Kaak3+EX+hnomQQ9YqPbOX65k1roy5HXuYXzdSgWv+b2bCRPIKP1ZvZDU14juvNTKRTQxnw==",
 			"cpu": [
 				"x64"
 			],
@@ -79,9 +79,9 @@
 			}
 		},
 		"node_modules/@couchbase/couchbase-linux-arm64-napi": {
-			"version": "4.2.8",
-			"resolved": "https://registry.npmjs.org/@couchbase/couchbase-linux-arm64-napi/-/couchbase-linux-arm64-napi-4.2.8.tgz",
-			"integrity": "sha512-hdufd2WEDDpiT7K/Uzfk+kAZc1mb3l8Ke0Aci7VphUH52MvGcYs1mYMVWT9SpXI1xafRzszFD1FkSgYS2tbhtg==",
+			"version": "4.2.9",
+			"resolved": "https://registry.npmjs.org/@couchbase/couchbase-linux-arm64-napi/-/couchbase-linux-arm64-napi-4.2.9.tgz",
+			"integrity": "sha512-/krjBtwfSE1lmpG6/PluFFi7++z75GCOjSQ4Pdmn+txcwjpy7G9hu9NKxBRUn5gBYO7q/5tp0Z3LxdN2c7haWA==",
 			"cpu": [
 				"arm64"
 			],
@@ -94,9 +94,9 @@
 			}
 		},
 		"node_modules/@couchbase/couchbase-linux-x64-napi": {
-			"version": "4.2.8",
-			"resolved": "https://registry.npmjs.org/@couchbase/couchbase-linux-x64-napi/-/couchbase-linux-x64-napi-4.2.8.tgz",
-			"integrity": "sha512-JhsGTLDGHTyUrp4H+nMMilLgeD63JWmdmwW+oL4ed4zL8ghwvthMzw0LUpEsOLxuDVxn/7aVo5UJhFLI2qtoJg==",
+			"version": "4.2.9",
+			"resolved": "https://registry.npmjs.org/@couchbase/couchbase-linux-x64-napi/-/couchbase-linux-x64-napi-4.2.9.tgz",
+			"integrity": "sha512-SCo5ZorStwIEXVDcTv23VXWurfrv3JS0hc3sayAP/Rfa+YClMmISAV7J+8V64PeHcfMIWBNCaCof/p/zk/gp0g==",
 			"cpu": [
 				"x64"
 			],
@@ -109,9 +109,9 @@
 			}
 		},
 		"node_modules/@couchbase/couchbase-linuxmusl-x64-napi": {
-			"version": "4.2.8",
-			"resolved": "https://registry.npmjs.org/@couchbase/couchbase-linuxmusl-x64-napi/-/couchbase-linuxmusl-x64-napi-4.2.8.tgz",
-			"integrity": "sha512-H3tCNcrtFzw3Hi4Q6cjEj37nHud138vSYkydeebHcw81zPD0prebeCedOmev8weBTzgtMpA4OAcx8yo+uZFG0g==",
+			"version": "4.2.9",
+			"resolved": "https://registry.npmjs.org/@couchbase/couchbase-linuxmusl-x64-napi/-/couchbase-linuxmusl-x64-napi-4.2.9.tgz",
+			"integrity": "sha512-d1Ax5SI24yzKFYKuaiazY7GgYLw10zN3i82zZAX2emPikitT0lopPhrDIj8ZXWG4t68+x7IT0qFrvSjpXfyOXQ==",
 			"cpu": [
 				"x64"
 			],
@@ -124,9 +124,9 @@
 			}
 		},
 		"node_modules/@couchbase/couchbase-win32-x64-napi": {
-			"version": "4.2.8",
-			"resolved": "https://registry.npmjs.org/@couchbase/couchbase-win32-x64-napi/-/couchbase-win32-x64-napi-4.2.8.tgz",
-			"integrity": "sha512-omaxgWrRI/t/PNxTn15f6kCcskVmc1KtjbCcvawIaHrb9/d/hnh3SetUbQXQa9LOUCYPtQ6Uucp/ExjwF2FdDg==",
+			"version": "4.2.9",
+			"resolved": "https://registry.npmjs.org/@couchbase/couchbase-win32-x64-napi/-/couchbase-win32-x64-napi-4.2.9.tgz",
+			"integrity": "sha512-sg9TKwqDim2GJ3DDztgr4x3EITxBHRX1zKi0VVcURpoRbSBEkrrKLmHFoB7a9nhaJp50W2ZqB60Y97KNTtmUEw==",
 			"cpu": [
 				"x64"
 			],
@@ -1631,9 +1631,9 @@
 			"integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
 		},
 		"node_modules/couchbase": {
-			"version": "4.2.8",
-			"resolved": "https://registry.npmjs.org/couchbase/-/couchbase-4.2.8.tgz",
-			"integrity": "sha512-lcrbhV0tHxsiJkaWR2zuJU+YFW4aMMzM0SVxXHtk77BLg16hwHqtUyfm7dwy2UUCZcUTLAJgODiyQ3LOXCcuuw==",
+			"version": "4.2.9",
+			"resolved": "https://registry.npmjs.org/couchbase/-/couchbase-4.2.9.tgz",
+			"integrity": "sha512-NtztuSLyi6GtQbLPBW7uuiRWj6VIh0PcHjtqEAG9nQXyhMkLjiDMGaibxx5rqTud0mai0J8Swif61ENdDRQasw==",
 			"hasInstallScript": true,
 			"dependencies": {
 				"cmake-js": "^7.2.1",
@@ -1643,12 +1643,12 @@
 				"node": ">=16"
 			},
 			"optionalDependencies": {
-				"@couchbase/couchbase-darwin-arm64-napi": "4.2.8",
-				"@couchbase/couchbase-darwin-x64-napi": "4.2.8",
-				"@couchbase/couchbase-linux-arm64-napi": "4.2.8",
-				"@couchbase/couchbase-linux-x64-napi": "4.2.8",
-				"@couchbase/couchbase-linuxmusl-x64-napi": "4.2.8",
-				"@couchbase/couchbase-win32-x64-napi": "4.2.8"
+				"@couchbase/couchbase-darwin-arm64-napi": "4.2.9",
+				"@couchbase/couchbase-darwin-x64-napi": "4.2.9",
+				"@couchbase/couchbase-linux-arm64-napi": "4.2.9",
+				"@couchbase/couchbase-linux-x64-napi": "4.2.9",
+				"@couchbase/couchbase-linuxmusl-x64-napi": "4.2.9",
+				"@couchbase/couchbase-win32-x64-napi": "4.2.9"
 			}
 		},
 		"node_modules/cross-env": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
 			],
 			"dependencies": {
 				"@parcel/watcher": "2.3.0",
-				"couchbase": "^4.2.9",
+				"couchbase": "4.2.9",
 				"desktop-trampoline": "https://github.com/desktop/desktop-trampoline/archive/refs/tags/v0.9.8.tar.gz",
 				"kerberos": "2.0.3",
 				"kerberos-plugins": "git+https://github.com/hackolade/kerberos.git",
@@ -25,7 +25,7 @@
 				"chai": "^4.3.10",
 				"cross-env": "^7.0.3",
 				"debug": "^4.3.4",
-				"electron": "^28.1.3",
+				"electron": "28.1.4",
 				"eslint": "^8.56.0",
 				"eslint-config-airbnb-base": "^15.0.0",
 				"eslint-plugin-import": "^2.29.1",
@@ -2065,9 +2065,9 @@
 			}
 		},
 		"node_modules/electron": {
-			"version": "28.1.3",
-			"resolved": "https://registry.npmjs.org/electron/-/electron-28.1.3.tgz",
-			"integrity": "sha512-NSFyTo6SndTPXzU18XRePv4LnjmuM9rF5GMKta1/kPmi02ISoSRonnD7wUlWXD2x53XyJ6d/TbSVesMW6sXkEQ==",
+			"version": "28.1.4",
+			"resolved": "https://registry.npmjs.org/electron/-/electron-28.1.4.tgz",
+			"integrity": "sha512-WE6go611KOhtH6efRPMnVC7FE7DCKnQ3ZyHFeI1DbaCy8OU4UjZ8/CZGcuZmZgRdxSBEHoHdgaJkWRHZzF0FOg==",
 			"dev": true,
 			"hasInstallScript": true,
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
 	},
 	"dependencies": {
 		"@parcel/watcher": "2.3.0",
-		"couchbase": "4.2.8",
+		"couchbase": "4.2.9",
 		"desktop-trampoline": "https://github.com/desktop/desktop-trampoline/archive/refs/tags/v0.9.8.tar.gz",
 		"kerberos": "2.0.3",
 		"kerberos-plugins": "git+https://github.com/hackolade/kerberos.git",
@@ -60,7 +60,7 @@
 				"to_build": false
 			},
 			"couchbase": {
-				"version": "28.4.0",
+				"version": "28.4.1",
 				"napi": true,
 				"prebuild_install": false,
 				"prebuilds_as_npm_packages": true,

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
 		"chai": "^4.3.10",
 		"cross-env": "^7.0.3",
 		"debug": "^4.3.4",
-		"electron": "^28.1.3",
+		"electron": "28.1.4",
 		"eslint": "^8.56.0",
 		"eslint-config-airbnb-base": "^15.0.0",
 		"eslint-plugin-import": "^2.29.1",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
 				"to_build": false
 			},
 			"couchbase": {
-				"version": "28.4.1",
+				"version": "28.4.2",
 				"napi": true,
 				"prebuild_install": false,
 				"prebuilds_as_npm_packages": true,

--- a/patches/couchbase+4.2.9.patch
+++ b/patches/couchbase+4.2.9.patch
@@ -1,37 +1,52 @@
 diff --git a/node_modules/couchbase/dist/binding.js b/node_modules/couchbase/dist/binding.js
-index b5d4a9c..f7948b2 100644
+index b5d4a9c..a45dcd1 100644
 --- a/node_modules/couchbase/dist/binding.js
 +++ b/node_modules/couchbase/dist/binding.js
-@@ -160,5 +160,5 @@ const binding = process.env.CN_PREBUILD_PATH_OVERRIDE
-     ? // eslint-disable-next-line @typescript-eslint/no-var-requires
-         require(process.env.CN_PREBUILD_PATH_OVERRIDE)
-     : // eslint-disable-next-line @typescript-eslint/no-var-requires
+@@ -153,12 +153,8 @@ var CppTxnFailureType;
+ var CppTxnExternalException;
+ (function (CppTxnExternalException) {
+ })(CppTxnExternalException || (exports.CppTxnExternalException = CppTxnExternalException = {}));
+-// CN_PREBUILD_PATH_OVERRIDE is meant to help for webpack scenarios.  Webpack's EnvironmentPlugin
+-// can be used to set the path of the desired prebuild which will allow the node-loader package
+-// to pull in the corresponding prebuild.
+-const binding = process.env.CN_PREBUILD_PATH_OVERRIDE
+-    ? // eslint-disable-next-line @typescript-eslint/no-var-requires
+-        require(process.env.CN_PREBUILD_PATH_OVERRIDE)
+-    : // eslint-disable-next-line @typescript-eslint/no-var-requires
 -        require('../scripts/prebuilds').loadPrebuild(path_1.default.resolve(__dirname, '..'));
-+        require('../scripts/prebuilds').loadPrebuild();
++
++const os = require('os');
++const binding = require(/* webpackIgnore: true */ `@hackolade/couchbase-${os.platform()}-${os.arch()}-napi`);
++
  exports.default = binding;
 diff --git a/node_modules/couchbase/package.json b/node_modules/couchbase/package.json
-index 67a1cbd..fac7566 100644
+index 8936c27..ca02bba 100644
 --- a/node_modules/couchbase/package.json
 +++ b/node_modules/couchbase/package.json
-@@ -61,9 +61,8 @@
-   "scripts": {
-     "install": "node ./scripts/install.js",
+@@ -20,7 +20,6 @@
+   "license": "Apache-2.0",
+   "name": "couchbase",
+   "dependencies": {
+-    "cmake-js": "^7.2.1",
+     "node-addon-api": "^7.0.0"
+   },
+   "devDependencies": {
+@@ -63,7 +62,6 @@
      "build": "cmake-js build && tsc",
--    "rebuild": "cmake-js rebuild && tsc",
-+    "rebuild": "node ./scripts/buildPrebuild.js",
+     "rebuild": "cmake-js rebuild && tsc",
      "prebuild": "node ./scripts/buildPrebuild.js",
 -    "prepare": "tsc",
      "help-prune": "node ./scripts/prune.js",
      "build-docs": "typedoc",
      "test": "ts-mocha test/*.test.*",
-@@ -81,86 +80,14 @@
+@@ -81,86 +79,13 @@
    "optionalDependencies": {
-     "@couchbase/couchbase-darwin-arm64-napi": "4.2.8",
-     "@couchbase/couchbase-darwin-x64-napi": "4.2.8",
--    "@couchbase/couchbase-linux-arm64-napi": "4.2.8",
--    "@couchbase/couchbase-linuxmusl-x64-napi": "4.2.8",
-     "@couchbase/couchbase-linux-x64-napi": "4.2.8",
-     "@couchbase/couchbase-win32-x64-napi": "4.2.8"
+     "@couchbase/couchbase-darwin-arm64-napi": "4.2.9",
+     "@couchbase/couchbase-darwin-x64-napi": "4.2.9",
+-    "@couchbase/couchbase-linux-arm64-napi": "4.2.9",
+-    "@couchbase/couchbase-linuxmusl-x64-napi": "4.2.9",
+     "@couchbase/couchbase-linux-x64-napi": "4.2.9",
+     "@couchbase/couchbase-win32-x64-napi": "4.2.9"
    },
    "files": [
      "LICENSE",
@@ -109,39 +124,7 @@ index 67a1cbd..fac7566 100644
 -    "deps/couchbase-cxx-cache/spdlog/*/spdlog/include/**/*",
 -    "deps/couchbase-cxx-cache/spdlog/*/spdlog/src/**/*",
 -    "deps/couchbase-cxx-cache/mozilla-ca-bundle.*"
-+    "scripts/prebuilds.js",
 +    "dist/*.{t,j}s"
    ]
  }
 \ No newline at end of file
-diff --git a/node_modules/couchbase/scripts/prebuilds.js b/node_modules/couchbase/scripts/prebuilds.js
-index 401866e..5d330ef 100644
---- a/node_modules/couchbase/scripts/prebuilds.js
-+++ b/node_modules/couchbase/scripts/prebuilds.js
-@@ -1,4 +1,5 @@
- const fs = require('fs')
-+const os = require('os')
- const path = require('path')
- var proc = require('child_process')
- 
-@@ -328,7 +329,7 @@ function isElectron() {
- }
- 
- function loadPrebuild(dir) {
--  return runtimeRequire(resolvePrebuild(dir))
-+  return require(/* webpackIgnore: true */ `@hackolade/couchbase-${os.platform()}-${os.arch()}-napi`);
- }
- 
- function matchBuild(name) {
-@@ -459,11 +460,5 @@ function resolvePrebuild(
- }
- 
- module.exports = {
--  ENV_TRUE,
--  buildBinary,
--  configureBinary,
--  getPrebuildsInfo,
-   loadPrebuild,
--  resolveLocalPrebuild,
--  resolvePrebuild,
- }


### PR DESCRIPTION
# Context

Example for generating, repackaging and republishing native modules for a couchbase updated version.

See https://app.gitbook.com/o/HBtg1gLTy0nw4NaX0MaV/s/bfdwYZ4RTsNHasAMVAKe/cross-platform-builds-in-docker/prebuild-native-modules/how-to-generate-patch-a-native-module-prebuild
